### PR TITLE
fix(#43): RiskManager equity 계산에 포지션 크기 반영

### DIFF
--- a/src/strategy/risk.py
+++ b/src/strategy/risk.py
@@ -103,6 +103,7 @@ class RiskManager:
         max_drawdown = self.config["max_drawdown"]
         max_daily_trades = self.config["max_daily_trades"]
         cooldown_after_loss = self.config["cooldown_after_loss"]
+        position_ratio = self.config["max_position_size"]
 
         in_position = False
         entry_price = 0.0
@@ -132,25 +133,29 @@ class RiskManager:
                     output[i] = -1
                     in_position = False
                     cooldown_remaining = cooldown_after_loss
-                    equity = equity * (price / entry_price)
+                    pnl_pct = price / entry_price - 1.0
+                    equity = equity * (1.0 + position_ratio * pnl_pct)
                     daily_trades += 1
                 elif self._check_take_profit(entry_price, price, take_profit):
                     output[i] = -1
                     in_position = False
-                    equity = equity * (price / entry_price)
+                    pnl_pct = price / entry_price - 1.0
+                    equity = equity * (1.0 + position_ratio * pnl_pct)
                     daily_trades += 1
                 elif self._check_trailing_stop(peak_price, price, trailing_stop):
                     output[i] = -1
                     in_position = False
                     cooldown_remaining = cooldown_after_loss
-                    equity = equity * (price / entry_price)
+                    pnl_pct = price / entry_price - 1.0
+                    equity = equity * (1.0 + position_ratio * pnl_pct)
                     daily_trades += 1
                 else:
                     peak_price = max(peak_price, price)
                     if signal == -1:
                         output[i] = -1
                         in_position = False
-                        equity = equity * (price / entry_price)
+                        pnl_pct = price / entry_price - 1.0
+                        equity = equity * (1.0 + position_ratio * pnl_pct)
                         daily_trades += 1
                     else:
                         output[i] = 0


### PR DESCRIPTION
## Summary
- equity 계산에 `max_position_size`(기본 0.95) 반영하여 MDD 계산 정확도 향상
- SL/TP/Trailing/일반매도 4곳 일괄 수정

Closes #43

## Changes
- `src/strategy/risk.py`: equity 계산 로직 수정

## Test plan
- [x] RiskManager 20개 테스트 통과
- [x] MDD 억제/허용 테스트 동작 확인
- [x] ruff lint 통과