### PR TITLE
docs(#48): Phase 3.5 백테스트 재실행 결과 분석

### DIFF
--- a/notebooks/04_backtest_analysis.ipynb
+++ b/notebooks/04_backtest_analysis.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3buxbte1jlk",
+   "source": "# 04. Backtest Analysis (Phase 3.5 수정 후)\n\nPhase 3.5 버그 수정 + 감성분석 모델 교체 후 백테스트 재실행 및 KPI 분석.\n\n**수정 사항**\n1. LSTM TimeSeriesDataset seq_length 데이터 누수 수정 (#41)\n2. 앙상블 out-of-fold stacking 구현 (#42)\n3. RiskManager equity 계산에 포지션 크기 반영 (#43)\n4. 감성분석 모델 교체: CardiffNLP → CryptoBERT + FinBERT (#47)\n5. 백테스트 엔진 스케일링된 가격 사용 버그 수정 (#51)\n\n**목표**\n- XGBoost + LSTM + 앙상블 모델 학습 후 Test 세트 백테스트\n- 1차 KPI 목표 충족 여부 확인 (Sharpe ≥ 1.0, MDD ≤ 25%, Win Rate ≥ 50%, PF ≥ 1.2)\n- 모델별 기여도 분석\n- 발견된 문제점 기록",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "rb9xxts9x6g",
+   "source": "import sys\nsys.path.insert(0, \"..\")\n\nimport json\nimport numpy as np\nimport pandas as pd\nimport plotly.graph_objects as go\nfrom plotly.subplots import make_subplots\n\nfrom src.data.collector import load_from_parquet\nfrom src.models.xgboost_model import XGBoostSignalModel\nfrom src.models.lstm_model import LSTMSignalModel\nfrom src.models.ensemble import EnsembleModel\nfrom src.backtest.engine import BacktestEngine\n\npd.set_option(\"display.float_format\", \"{:.4f}\".format)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rgrl0wuanbo",
+   "source": "## 1. 데이터 및 모델 로드",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "eyvxlg7ish",
+   "source": "# 데이터 로드\ntrain_df = load_from_parquet(\"../data/processed/train.parquet\")\nval_df = load_from_parquet(\"../data/processed/val.parquet\")\ntest_df = load_from_parquet(\"../data/processed/test.parquet\")\n\nprint(f\"Train: {len(train_df):,}행 ({train_df.index.min()} ~ {train_df.index.max()})\")\nprint(f\"Val:   {len(val_df):,}행 ({val_df.index.min()} ~ {val_df.index.max()})\")\nprint(f\"Test:  {len(test_df):,}행 ({test_df.index.min()} ~ {test_df.index.max()})\")\nprint(f\"피처 수: {len(train_df.columns) - 1} (target 제외)\")\n\n# 모델 로드\nxgb = XGBoostSignalModel.load(\"../data/models\")\nlstm = LSTMSignalModel.load(\"../data/models\")\nensemble = EnsembleModel.load(\"../data/models\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4eueynhz97y",
+   "source": "## 2. 예측 생성 및 정렬",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "umt0e3fk9hm",
+   "source": "# XGBoost 예측\nxgb_test_proba = xgb.predict_proba(test_df)\n\n# LSTM 예측 (seq_length offset)\nseq_length = lstm.config.get(\"seq_length\", 60)\nlstm_test_proba = lstm.predict_proba(test_df)\nn_lstm = len(lstm_test_proba)\n\n# LSTM은 seq_length만큼 짧으므로 정렬\nxgb_test_aligned = xgb_test_proba[seq_length - 1 : seq_length - 1 + n_lstm]\ntest_df_aligned = test_df.iloc[seq_length - 1 : seq_length - 1 + n_lstm]\n\nprint(f\"seq_length: {seq_length}\")\nprint(f\"정렬 후 Test 크기: {len(test_df_aligned):,}행\")\nprint(f\"XGBoost proba shape: {xgb_test_aligned.shape}\")\nprint(f\"LSTM proba shape: {lstm_test_proba.shape}\")\n\n# 앙상블 신호 생성\nbase_predictions = {\"xgboost\": xgb_test_aligned, \"lstm\": lstm_test_proba}\nsignals = ensemble.predict(base_predictions)\n\n# 신호 분포\nunique, counts = np.unique(signals, return_counts=True)\nlabel_map = {-1: \"Sell\", 0: \"Hold\", 1: \"Buy\"}\nprint(\"\\n신호 분포:\")\nfor u, c in zip(unique, counts):\n    print(f\"  {label_map.get(u, u)}: {c:,} ({c/len(signals)*100:.1f}%)\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "idp9p2tjl2",
+   "source": "## 3. 백테스트 실행",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ceuodlqvahr",
+   "source": "engine = BacktestEngine(config_path=\"../configs/trading_config.yaml\")\nresult = engine.run(test_df_aligned, signals)\n\n# KPI 출력\nprint(\"=\" * 60)\nprint(\"         BACKTEST RESULTS (Phase 3.5 수정 후)\")\nprint(\"=\" * 60)\nfor k, v in result.metrics.items():\n    if isinstance(v, float):\n        print(f\"  {k:.<30} {v:>12.4f}\")\n    else:\n        print(f\"  {k:.<30} {v:>12}\")\nprint(\"=\" * 60)\n\n# 1차 KPI 목표 비교\ntargets = {\n    \"sharpe_ratio\": (\">=\", 1.0),\n    \"max_drawdown\": (\">=\", -0.25),\n    \"win_rate\": (\">=\", 0.50),\n    \"profit_factor\": (\">=\", 1.2),\n}\nprint(\"\\n1차 KPI 목표 비교:\")\nfor metric, (op, target) in targets.items():\n    actual = result.metrics.get(metric, 0)\n    passed = actual >= target\n    status = \"PASS ✓\" if passed else \"FAIL ✗\"\n    print(f\"  {metric:.<25} {actual:>8.4f} {op} {target:>6.2f}  → {status}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "noxggm4qpu",
+   "source": "## 4. Equity Curve 시각화",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7ck1xi6e10g",
+   "source": "# Equity curve vs Buy & Hold (원본 가격 사용)\ninitial = result.config[\"initial_capital\"]\nprice_col = \"close_raw\" if \"close_raw\" in test_df_aligned.columns else \"close\"\nbh_equity = initial * (test_df_aligned[price_col] / test_df_aligned[price_col].iloc[0])\n\nfig = make_subplots(\n    rows=2, cols=1, shared_xaxes=True, vertical_spacing=0.05,\n    row_heights=[0.7, 0.3],\n    subplot_titles=(\"Equity Curve\", \"Drawdown\")\n)\n\nfig.add_trace(\n    go.Scatter(x=result.equity_curve.index, y=result.equity_curve.values,\n               name=\"Strategy\", line=dict(color=\"blue\", width=1.5)),\n    row=1, col=1\n)\nfig.add_trace(\n    go.Scatter(x=bh_equity.index, y=bh_equity.values,\n               name=\"Buy & Hold\", line=dict(color=\"gray\", width=1, dash=\"dash\")),\n    row=1, col=1\n)\n\n# Drawdown\npeak = result.equity_curve.cummax()\ndrawdown = (result.equity_curve - peak) / peak\nfig.add_trace(\n    go.Scatter(x=drawdown.index, y=drawdown.values,\n               name=\"Drawdown\", fill=\"tozeroy\",\n               line=dict(color=\"red\", width=1), fillcolor=\"rgba(255,0,0,0.2)\"),\n    row=2, col=1\n)\n\nfig.update_layout(height=600, showlegend=True)\nfig.update_yaxes(title_text=\"USD\", row=1, col=1)\nfig.update_yaxes(title_text=\"Drawdown %\", row=2, col=1)\nfig.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "q1s9htr654",
+   "source": "## 5. 거래 분석",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "nd9w97yeyia",
+   "source": "# 거래별 PnL 분포\ntrades = result.trades\nprint(f\"총 거래 수: {len(trades)}\")\nprint(f\"평균 보유 시간: {trades['duration'].mean()}\")\nprint()\n\n# PnL 히스토그램\nfig = make_subplots(rows=1, cols=2, subplot_titles=(\"거래별 PnL (%)\", \"거래별 PnL (USD)\"))\n\nfig.add_trace(\n    go.Histogram(x=trades[\"pnl\"] * 100, nbinsx=30, marker_color=\"steelblue\", name=\"PnL %\"),\n    row=1, col=1\n)\nfig.add_trace(\n    go.Histogram(x=trades[\"pnl_abs\"], nbinsx=30, marker_color=\"coral\", name=\"PnL USD\"),\n    row=1, col=2\n)\n\nfig.update_xaxes(title_text=\"PnL (%)\", row=1, col=1)\nfig.update_xaxes(title_text=\"PnL (USD)\", row=1, col=2)\nfig.update_layout(height=350, showlegend=False)\nfig.show()\n\n# 극단 거래 확인\nprint(\"Top 5 최악의 거래:\")\nworst = trades.nsmallest(5, \"pnl\")[[\"entry_time\", \"exit_time\", \"entry_price\", \"exit_price\", \"pnl\", \"pnl_abs\", \"duration\"]]\nprint(worst.to_string())\nprint()\nprint(\"Top 5 최고의 거래:\")\nbest = trades.nlargest(5, \"pnl\")[[\"entry_time\", \"exit_time\", \"entry_price\", \"exit_price\", \"pnl\", \"pnl_abs\", \"duration\"]]\nprint(best.to_string())",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ppuducy0a2i",
+   "source": "## 6. 앙상블 모델 기여도 분석",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "lavvdzaxyyj",
+   "source": "# 앙상블 메타 모델 정보\nmeta = ensemble.get_metadata()\nprint(\"앙상블 메타데이터:\")\nfor k, v in meta.items():\n    print(f\"  {k}: {v}\")\n\n# 모델별 기여도\ncontributions = ensemble.get_contributions()\nprint(f\"\\n모델별 기여도: {contributions}\")\n\nfig = go.Figure(go.Bar(\n    x=list(contributions.keys()),\n    y=list(contributions.values()),\n    marker_color=[\"steelblue\", \"coral\"],\n    text=[f\"{v:.1%}\" for v in contributions.values()],\n    textposition=\"auto\"\n))\nfig.update_layout(\n    title=\"앙상블 모델별 기여도\",\n    yaxis_title=\"기여도\", height=350\n)\nfig.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0p296treqeh",
+   "source": "## 7. 발견된 문제점 및 다음 단계\n\n### Phase 3.5 버그 수정 효과\n| 지표 | 수정 전 (스케일링된 가격) | 수정 후 (원본 가격) | 비고 |\n|------|--------------------------|---------------------|------|\n| MDD | -158% (비현실적) | -43.62% | 물리적으로 가능한 범위 |\n| Final Capital | -$989 (음수) | $6,270 | 합리적 결과 |\n| worst_trade | -113% (불가능) | -39.10% | 정상 범위 |\n| 총 거래 수 | 다수 | 1건 | Sell 신호 0건 |\n\n### 핵심 문제점\n1. **Sell 신호 0건**: 앙상블이 Hold 95.7% + Buy 4.3%만 생성, Sell은 전혀 없음\n   - 매수 후 매도 없이 마지막 bar에서 강제 청산 → 거래 1건\n   - 원인: 메타 모델이 Sell 클래스를 학습하지 못함\n2. **LSTM 기여도 1.88%**: 사실상 XGBoost 단독 모델\n   - LSTM val_loss가 0.927로 수렴 (랜덤 수준 ~1.099 대비 개선은 있으나 미미)\n3. **모든 KPI 미달**: Sharpe -2.33, MDD -43.62%, Win Rate 0%, PF 0.0\n4. **긍정적 신호**: excess_return +1.32% (Buy & Hold 대비 소폭 우위)\n\n### 원인 분석\n- 3-class 분류(Buy/Hold/Sell)에서 Hold가 압도적 다수 → 모델이 Hold 편향\n- target_threshold 0.5%가 너무 낮아 노이즈에 민감할 가능성\n- 1시간 캔들 단일 타임프레임으로는 추세 파악 한계\n\n### 다음 단계 (Phase 6: 전략 고도화)\n- [ ] 마켓 레짐 감지 모듈 (상승장/하락장/횡보장 분류)\n- [ ] 멀티 타임프레임 분석 (4h, 1d 추세 확인 → 1h 진입)\n- [ ] target_threshold 튜닝 및 2-class(Buy/Sell) vs 3-class 비교\n- [ ] 동적 포지션 사이징 (Kelly Criterion / 변동성 기반)\n- [ ] LSTM 아키텍처 개선 (Attention, Transformer 등)",
+   "metadata": {}
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- #51 수정 후 전처리/모델 재학습/백테스트 재실행
- MDD -158% → -43.62%로 물리적으로 합리적 결과 확인
- 모든 KPI 미달 → Phase 6 전략 고도화 필요성 기록

Closes #48

## Changes
- `notebooks/04_backtest_analysis.ipynb`: 수정 전/후 비교표, Sell 신호 0건 문제, Phase 6 방향 기록

## Test plan
- [x] 전처리 파이프라인 재실행 (close_raw 포함 확인)
- [x] XGBoost, LSTM, 앙상블 재학습 완료
- [x] 백테스트 결과 합리성 검증 (MDD, worst_trade 범위)
- [x] 노트북 코드 실행 확인