### PR TITLE
fix(#59): signal/target threshold 하향 조정

### DIFF
--- a/configs/model_config.yaml
+++ b/configs/model_config.yaml
@@ -4,7 +4,7 @@
 general:
   random_seed: 42
   target_horizon: 4          # 예측 기간 (캔들 수)
-  target_threshold: 0.005    # 매수/매도 판단 기준 (0.5%)
+  target_threshold: 0.003    # 매수/매도 판단 기준 (0.3%)
   train_ratio: 0.6
   val_ratio: 0.2
   test_ratio: 0.2
@@ -41,7 +41,7 @@ lstm:
 ensemble:
   method: "logistic_regression"  # meta learner
   weights: null                  # null = 자동 학습
-  signal_threshold: 0.35         # Buy/Sell 확률이 이 값 초과 시 신호 생성
+  signal_threshold: 0.25         # Buy/Sell 확률이 이 값 초과 시 신호 생성
 
 sentiment:
   provider: "dual"           # "dual", "crypto", "finbert", "bedrock"


### PR DESCRIPTION
## Summary
- `target_threshold`: 0.005 → 0.003 (Hold 과다 라벨링 완화, Buy/Sell 학습 샘플 확보)
- `signal_threshold`: 0.35 → 0.25 (거래 빈도 증가, 23건 → 60~100건 예상)

## Changes
- `configs/model_config.yaml`: threshold 2개 값 조정

## Test Plan
- [x] 전체 테스트 351개 통과, 커버리지 91%
- [x] config 값만 변경으로 코드 로직 영향 없음

Closes #59