### PR TITLE
fix(#60): TP/SL/Trailing Stop 재조정 및 ATR 동적 스탑 추가

### DIFF
--- a/configs/trading_config.yaml
+++ b/configs/trading_config.yaml
@@ -22,8 +22,10 @@ risk_management:
   max_drawdown: 0.20         # 20% MDD 도달 시 거래 중단
   max_position_size: 0.95    # 최대 포지션 크기
   stop_loss: 0.03            # 3% 손절
-  take_profit: 0.06          # 6% 익절
-  trailing_stop: 0.02        # 2% 트레일링 스탑
+  take_profit: 0.04          # 4% 익절 (이전 6%: 평균 수익 2.62% 대비 과다)
+  trailing_stop: 0.03        # 3% 트레일링 스탑 (이전 2%: BTC 1h ATR 대비 과소)
+  use_atr_stops: false        # true면 ATR 기반 동적 스탑 사용
+  atr_stop_multiplier: 2.0   # ATR × 배수 = 동적 스탑 거리
   max_daily_trades: 10       # 일일 최대 거래 수
   cooldown_after_loss: 2     # 손절 후 대기 캔들 수
 

--- a/src/strategy/risk.py
+++ b/src/strategy/risk.py
@@ -25,12 +25,14 @@ class RiskManager:
 
     DEFAULT_PARAMS: dict = {
         "stop_loss": 0.03,
-        "take_profit": 0.06,
-        "trailing_stop": 0.02,
+        "take_profit": 0.04,
+        "trailing_stop": 0.03,
         "max_drawdown": 0.20,
         "max_position_size": 0.95,
         "max_daily_trades": 10,
         "cooldown_after_loss": 2,
+        "use_atr_stops": False,
+        "atr_stop_multiplier": 2.0,
     }
 
     def __init__(
@@ -96,6 +98,15 @@ class RiskManager:
 
         close = df["close"].values
         output = np.zeros(len(df), dtype=int)
+
+        use_atr = self.config["use_atr_stops"]
+        atr_mult = self.config["atr_stop_multiplier"]
+        atr_values: np.ndarray | None = None
+        if use_atr and "atr_14" in df.columns:
+            atr_values = df["atr_14"].values
+        elif use_atr:
+            logger.warning("use_atr_stops=True이지만 atr_14 컬럼 없음, 고정 스탑 사용")
+            use_atr = False
 
         stop_loss = self.config["stop_loss"]
         take_profit = self.config["take_profit"]
@@ -173,6 +184,12 @@ class RiskManager:
                         peak_price = price
                         in_position = True
                         daily_trades += 1
+                        # ATR 기반 동적 스탑 설정
+                        if use_atr and atr_values is not None:
+                            atr_pct = atr_values[i] / price
+                            stop_loss = max(atr_pct * atr_mult, 0.01)
+                            take_profit = max(atr_pct * atr_mult * 2, 0.02)
+                            trailing_stop = max(atr_pct * atr_mult, 0.01)
                 else:
                     output[i] = 0
 

--- a/tests/unit/test_risk_manager.py
+++ b/tests/unit/test_risk_manager.py
@@ -65,18 +65,19 @@ class TestInit:
         """기본 파라미터가 적용되어야 한다."""
         rm = RiskManager()
         assert rm.config["stop_loss"] == 0.03
-        assert rm.config["take_profit"] == 0.06
-        assert rm.config["trailing_stop"] == 0.02
+        assert rm.config["take_profit"] == 0.04
+        assert rm.config["trailing_stop"] == 0.03
         assert rm.config["max_drawdown"] == 0.20
         assert rm.config["max_daily_trades"] == 10
         assert rm.config["cooldown_after_loss"] == 2
+        assert rm.config["use_atr_stops"] is False
 
     def test_custom_config(self) -> None:
         """커스텀 설정이 기본값을 오버라이드해야 한다."""
         rm = RiskManager(config={"stop_loss": 0.05, "max_daily_trades": 5})
         assert rm.config["stop_loss"] == 0.05
         assert rm.config["max_daily_trades"] == 5
-        assert rm.config["take_profit"] == 0.06  # 기본값 유지
+        assert rm.config["take_profit"] == 0.04  # 기본값 유지
 
     def test_from_config_file(self, tmp_path: object) -> None:
         """YAML 설정 파일에서 risk_management 섹션을 로드해야 한다."""
@@ -93,7 +94,7 @@ class TestInit:
         rm = RiskManager(config_path=config_path)
         assert rm.config["stop_loss"] == 0.05
         assert rm.config["take_profit"] == 0.10
-        assert rm.config["trailing_stop"] == 0.02  # 기본값 유지
+        assert rm.config["trailing_stop"] == 0.03  # 기본값 유지
 
 
 # ---------------------------------------------------------------------------
@@ -151,9 +152,9 @@ class TestTakeProfit:
     """익절 테스트."""
 
     def test_take_profit_triggers_sell(self, risk_manager: RiskManager) -> None:
-        """가격이 진입가 대비 6% 이상 상승하면 강제 매도해야 한다."""
-        # 100에서 매수 → 106.1로 상승 (6.1% 상승, TP 트리거)
-        closes = [100.0, 103.0, 106.1]
+        """가격이 진입가 대비 4% 이상 상승하면 강제 매도해야 한다."""
+        # 100에서 매수 → 104.1로 상승 (4.1% 상승, TP 트리거)
+        closes = [100.0, 102.0, 104.1]
         df = _make_ohlcv(closes)
         signals = np.array([1, 0, 0])
 
@@ -163,8 +164,8 @@ class TestTakeProfit:
 
     def test_take_profit_not_triggered(self, risk_manager: RiskManager) -> None:
         """가격이 TP 미만으로 상승하면 매도하지 않아야 한다."""
-        # 100에서 매수 → 105로 상승 (5%, TP 미도달)
-        closes = [100.0, 103.0, 105.0]
+        # 100에서 매수 → 103.5로 상승 (3.5%, TP 4% 미도달)
+        closes = [100.0, 102.0, 103.5]
         df = _make_ohlcv(closes)
         signals = np.array([1, 0, 0])
 
@@ -385,3 +386,59 @@ class TestProcessSignals:
 
         with pytest.raises(ValueError, match="불일치"):
             risk_manager.process_signals(df, signals)
+
+
+class TestAtrDynamicStops:
+    """ATR 기반 동적 스탑 테스트."""
+
+    def test_atr_stops_use_atr_values(self) -> None:
+        """use_atr_stops=True이면 ATR 기반으로 스탑이 계산되어야 한다."""
+        rm = RiskManager(config={
+            "use_atr_stops": True,
+            "atr_stop_multiplier": 2.0,
+            "stop_loss": 0.03,
+            "take_profit": 0.04,
+            "trailing_stop": 0.03,
+        })
+        # ATR=1000 → atr_pct=1000/100000=0.01 → SL=0.02, TP=0.04, TS=0.02
+        closes = [100000.0, 100000.0, 97500.0]  # -2.5% drop
+        df = _make_ohlcv(closes)
+        df["atr_14"] = [1000.0, 1000.0, 1000.0]
+        signals = np.array([1, 0, 0])
+
+        result = rm.process_signals(df, signals)
+        # ATR SL = 0.01*2 = 0.02, drop is 2.5% > 2% → 스탑로스 발동
+        assert result[0] == 1
+        assert result[2] == -1
+
+    def test_atr_stops_no_atr_column_falls_back(self) -> None:
+        """atr_14 컬럼이 없으면 고정 스탑으로 폴백해야 한다."""
+        rm = RiskManager(config={
+            "use_atr_stops": True,
+            "atr_stop_multiplier": 2.0,
+            "stop_loss": 0.03,
+            "take_profit": 0.04,
+            "trailing_stop": 0.03,
+        })
+        closes = [100.0, 101.0, 102.0]
+        df = _make_ohlcv(closes)  # atr_14 없음
+        signals = np.array([1, 0, -1])
+
+        result = rm.process_signals(df, signals)
+        assert result[0] == 1  # 고정 스탑으로 정상 작동
+
+    def test_atr_stops_disabled_uses_fixed(self) -> None:
+        """use_atr_stops=False면 고정 스탑을 사용해야 한다."""
+        rm = RiskManager(config={
+            "use_atr_stops": False,
+            "stop_loss": 0.03,
+            "take_profit": 0.04,
+            "trailing_stop": 0.03,
+        })
+        closes = [100.0, 96.5]  # -3.5% drop > SL 3%
+        df = _make_ohlcv(closes)
+        signals = np.array([1, 0])
+
+        result = rm.process_signals(df, signals)
+        assert result[0] == 1
+        assert result[1] == -1  # 고정 SL 3% 발동


### PR DESCRIPTION
## Summary
- `take_profit`: 6% → 4% (평균 수익 2.62%에 맞춤)
- `trailing_stop`: 2% → 3% (BTC 1h ATR 대비 과소 → 조기 청산 방지)
- ATR 기반 동적 스탑 옵션 추가 (`use_atr_stops`, `atr_stop_multiplier`)

## Changes
- `configs/trading_config.yaml`: TP/trailing 값 조정, ATR 설정 추가
- `src/strategy/risk.py`: DEFAULT_PARAMS 업데이트, ATR 기반 SL/TP/TS 계산 로직
- `tests/unit/test_risk_manager.py`: ATR 동적 스탑 테스트 3건 추가, 기존 테스트 기댓값 업데이트

## Test Plan
- [x] `test_atr_stops_use_atr_values` — ATR 기반 스탑 발동 확인
- [x] `test_atr_stops_no_atr_column_falls_back` — atr_14 없을 때 고정 스탑 폴백
- [x] `test_atr_stops_disabled_uses_fixed` — 비활성 시 고정 스탑 사용
- [x] 전체 테스트 354개 통과, 커버리지 91%

Closes #60