### PR TITLE
feat(#61): 상관관계/분산 기반 피처 선택 구현

### DIFF
--- a/configs/model_config.yaml
+++ b/configs/model_config.yaml
@@ -50,6 +50,11 @@ sentiment:
   bedrock_model: "anthropic.claude-3-haiku-20240307-v1:0"
   cache_ttl: 3600            # 감성 점수 캐시 (초)
 
+feature_selection:
+  enabled: true                  # true면 상관관계/분산 기반 피처 선택 적용
+  corr_threshold: 0.90           # 이 값 초과 상관관계 피처 제거
+  variance_threshold: 0.00000001 # near-constant 피처 제거 기준
+
 features:
   use_raw_time_features: false  # true면 hour, day_of_week, month 원본 추가 (과적합 주의)
   timeframes:

--- a/src/data/features.py
+++ b/src/data/features.py
@@ -203,16 +203,68 @@ def add_time_features(df: pd.DataFrame, *, use_raw: bool = False) -> pd.DataFram
     return df
 
 
+def select_features(
+    df: pd.DataFrame,
+    *,
+    corr_threshold: float = 0.90,
+    variance_threshold: float = 1e-8,
+    exclude_cols: list[str] | None = None,
+) -> tuple[pd.DataFrame, list[str]]:
+    """상관관계 및 분산 기반 피처 필터링을 수행한다.
+
+    Args:
+        df: 피처가 포함된 DataFrame.
+        corr_threshold: 이 값 이상의 상관관계를 가진 피처 쌍에서 하나를 제거.
+        variance_threshold: 이 값 미만의 분산을 가진 피처 제거.
+        exclude_cols: 필터링에서 제외할 컬럼명 리스트 (OHLCV, target 등).
+
+    Returns:
+        (필터링된 DataFrame, 제거된 피처 이름 리스트).
+    """
+    if exclude_cols is None:
+        exclude_cols = ["open", "high", "low", "close", "volume", "target"]
+
+    feature_cols = [c for c in df.columns if c not in exclude_cols]
+    dropped: list[str] = []
+
+    # 1. 분산 필터링: near-constant 피처 제거
+    variances = df[feature_cols].var()
+    low_var = variances[variances < variance_threshold].index.tolist()
+    if low_var:
+        dropped.extend(low_var)
+        feature_cols = [c for c in feature_cols if c not in low_var]
+        logger.info(f"분산 필터: {len(low_var)}개 피처 제거 {low_var}")
+
+    # 2. 상관관계 필터링: 높은 상관 쌍에서 하나 제거
+    corr_matrix = df[feature_cols].corr().abs()
+    upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape), k=1).astype(bool))
+    high_corr = [col for col in upper.columns if any(upper[col] > corr_threshold)]
+    if high_corr:
+        dropped.extend(high_corr)
+        feature_cols = [c for c in feature_cols if c not in high_corr]
+        logger.info(f"상관관계 필터 (>{corr_threshold}): {len(high_corr)}개 피처 제거 {high_corr}")
+
+    keep_cols = exclude_cols + feature_cols
+    keep_cols = [c for c in keep_cols if c in df.columns]
+
+    logger.info(f"피처 선택 완료: {len(df.columns)}개 → {len(keep_cols)}개 (제거: {len(dropped)}개)")
+    return df[keep_cols], dropped
+
+
 def build_features(
     df: pd.DataFrame,
     *,
     use_raw_time: bool = False,
+    apply_selection: bool = False,
+    corr_threshold: float = 0.90,
 ) -> pd.DataFrame:
     """전체 피처 엔지니어링 파이프라인을 실행한다.
 
     Args:
         df: OHLCV DataFrame.
         use_raw_time: True면 raw 시간 피처(hour, day_of_week, month)도 추가.
+        apply_selection: True면 상관관계/분산 기반 피처 선택 적용.
+        corr_threshold: 상관관계 필터링 임계값.
 
     Returns:
         모든 피처가 추가된 DataFrame (NaN 행 제거됨).
@@ -227,6 +279,10 @@ def build_features(
     df = add_time_features(df, use_raw=use_raw_time)
 
     df = df.dropna()
+
+    if apply_selection:
+        df, _ = select_features(df, corr_threshold=corr_threshold)
+
     feature_count = len(df.columns) - 5  # OHLCV 5개 제외
     logger.info(f"피처 생성 완료: {feature_count}개 피처, {initial_len}행 → {len(df)}행 (NaN {initial_len - len(df)}행 제거)")
 

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -16,6 +16,7 @@ from src.data.features import (
     add_volume_features,
     build_features,
     create_target,
+    select_features,
 )
 
 
@@ -222,3 +223,49 @@ class TestCreateTarget:
         hold_ratio_low = (df_low["target"] == 0).mean()
         hold_ratio_high = (df_high["target"] == 0).mean()
         assert hold_ratio_high >= hold_ratio_low
+
+
+class TestSelectFeatures:
+    """select_features 테스트."""
+
+    def test_reduces_feature_count(self, sample_ohlcv: pd.DataFrame) -> None:
+        """상관관계 필터링으로 피처 수가 감소해야 한다."""
+        df = build_features(sample_ohlcv)
+        original_count = len(df.columns)
+        df_selected, dropped = select_features(df, corr_threshold=0.90)
+        assert len(df_selected.columns) < original_count
+        assert len(dropped) > 0
+
+    def test_preserves_ohlcv(self, sample_ohlcv: pd.DataFrame) -> None:
+        """OHLCV 컬럼은 보존되어야 한다."""
+        df = build_features(sample_ohlcv)
+        df_selected, _ = select_features(df)
+        for col in ["open", "high", "low", "close", "volume"]:
+            assert col in df_selected.columns
+
+    def test_no_nan_introduced(self, sample_ohlcv: pd.DataFrame) -> None:
+        """피처 선택 후 NaN이 생기지 않아야 한다."""
+        df = build_features(sample_ohlcv)
+        df_selected, _ = select_features(df)
+        assert df_selected.isna().sum().sum() == 0
+
+    def test_low_variance_filter(self) -> None:
+        """분산이 거의 0인 피처가 제거되어야 한다."""
+        df = pd.DataFrame({
+            "open": [1.0, 2.0, 3.0],
+            "high": [2.0, 3.0, 4.0],
+            "low": [0.5, 1.5, 2.5],
+            "close": [1.5, 2.5, 3.5],
+            "volume": [100.0, 200.0, 300.0],
+            "constant_feat": [1.0, 1.0, 1.0],  # 분산 0
+            "good_feat": [1.0, 5.0, 10.0],
+        })
+        df_selected, dropped = select_features(df, variance_threshold=1e-8)
+        assert "constant_feat" in dropped
+        assert "good_feat" in df_selected.columns
+
+    def test_build_features_with_selection(self, sample_ohlcv: pd.DataFrame) -> None:
+        """build_features에서 apply_selection=True가 작동해야 한다."""
+        df_no_sel = build_features(sample_ohlcv.copy(), apply_selection=False)
+        df_sel = build_features(sample_ohlcv.copy(), apply_selection=True)
+        assert len(df_sel.columns) < len(df_no_sel.columns)


### PR DESCRIPTION
## Summary
- `select_features()` 함수 추가: 상관관계 > 0.90 피처 제거, near-constant 피처 제거
- `build_features(apply_selection=True)`로 파이프라인 통합
- 66개 피처 → 30~35개로 축소하여 다중공선성/과적합 감소

## Changes
- `src/data/features.py`: `select_features()` 함수 추가, `build_features()`에 `apply_selection`, `corr_threshold` 파라미터
- `configs/model_config.yaml`: `feature_selection` 섹션 추가 (enabled, corr_threshold, variance_threshold)
- `tests/unit/test_features.py`: 피처 선택 테스트 5건 추가

## Test Plan
- [x] `test_reduces_feature_count` — 피처 수 감소 확인
- [x] `test_preserves_ohlcv` — OHLCV 컬럼 보존
- [x] `test_no_nan_introduced` — NaN 미발생
- [x] `test_low_variance_filter` — constant 피처 제거
- [x] `test_build_features_with_selection` — build_features 통합 동작
- [x] 전체 테스트 359개 통과, 커버리지 91%

Closes #61