### PR TITLE
feat(#34): DynamoDB 테이블 + 포지션 관리 모듈

### DIFF
--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -4,6 +4,7 @@ import * as cdk from "aws-cdk-lib";
 import { CommonStack } from "../lib/common-stack";
 import { DataStack } from "../lib/data-stack";
 import { EcrStack } from "../lib/ecr-stack";
+import { TradingStack } from "../lib/trading-stack";
 
 const app = new cdk.App();
 
@@ -36,4 +37,10 @@ new DataStack(app, `CryptoSentinel-Data-${envName}`, {
   tradingSecret: common.tradingSecret,
   env: awsEnv,
   description: `CryptoSentinel 데이터 수집 파이프라인 (${envName})`,
+});
+
+new TradingStack(app, `CryptoSentinel-Trading-${envName}`, {
+  envName,
+  env: awsEnv,
+  description: `CryptoSentinel 트레이딩 엔진 (${envName})`,
 });

--- a/infra/lib/trading-stack.ts
+++ b/infra/lib/trading-stack.ts
@@ -1,0 +1,71 @@
+import * as cdk from "aws-cdk-lib";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+export interface TradingStackProps extends cdk.StackProps {
+  envName: string;
+}
+
+export class TradingStack extends cdk.Stack {
+  public readonly positionsTable: dynamodb.Table;
+  public readonly tradesTable: dynamodb.Table;
+  public readonly botStateTable: dynamodb.Table;
+
+  constructor(scope: Construct, id: string, props: TradingStackProps) {
+    super(scope, id, props);
+
+    const { envName } = props;
+
+    // DynamoDB: 현재 오픈 포지션
+    this.positionsTable = new dynamodb.Table(this, "PositionsTable", {
+      tableName: `cryptosentinel-positions-${envName}`,
+      partitionKey: { name: "symbol", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy:
+        envName === "prod"
+          ? cdk.RemovalPolicy.RETAIN
+          : cdk.RemovalPolicy.DESTROY,
+      pointInTimeRecoverySpecification: envName === "prod" ? { pointInTimeRecoveryEnabled: true } : undefined,
+    });
+
+    // DynamoDB: 완료된 거래 이력
+    this.tradesTable = new dynamodb.Table(this, "TradesTable", {
+      tableName: `cryptosentinel-trades-${envName}`,
+      partitionKey: { name: "symbol", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "entry_time", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy:
+        envName === "prod"
+          ? cdk.RemovalPolicy.RETAIN
+          : cdk.RemovalPolicy.DESTROY,
+      pointInTimeRecoverySpecification: envName === "prod" ? { pointInTimeRecoveryEnabled: true } : undefined,
+    });
+
+    // DynamoDB: 봇 제어 상태
+    this.botStateTable = new dynamodb.Table(this, "BotStateTable", {
+      tableName: `cryptosentinel-bot-state-${envName}`,
+      partitionKey: { name: "key", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy:
+        envName === "prod"
+          ? cdk.RemovalPolicy.RETAIN
+          : cdk.RemovalPolicy.DESTROY,
+    });
+
+    // Outputs
+    new cdk.CfnOutput(this, "PositionsTableName", {
+      value: this.positionsTable.tableName,
+      exportName: `${envName}-PositionsTableName`,
+    });
+
+    new cdk.CfnOutput(this, "TradesTableName", {
+      value: this.tradesTable.tableName,
+      exportName: `${envName}-TradesTableName`,
+    });
+
+    new cdk.CfnOutput(this, "BotStateTableName", {
+      value: this.botStateTable.tableName,
+      exportName: `${envName}-BotStateTableName`,
+    });
+  }
+}

--- a/src/strategy/portfolio.py
+++ b/src/strategy/portfolio.py
@@ -1,0 +1,301 @@
+"""포지션 및 거래 관리 모듈.
+
+로컬 dict 모드와 DynamoDB 모드를 지원하여,
+백테스트/테스트 시에는 인메모리로, Lambda 배포 시에는 DynamoDB로 동작한다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Literal
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from loguru import logger
+
+
+@dataclass
+class Position:
+    """오픈 포지션 정보.
+
+    Attributes:
+        symbol: 거래 심볼 (e.g., "BTC/USDT").
+        side: 포지션 방향 ("long" | "short").
+        entry_price: 진입 가격.
+        size: 포지션 크기 (자본 비율, 0~1).
+        entry_time: 진입 시각 (ISO 8601).
+    """
+
+    symbol: str
+    side: Literal["long", "short"]
+    entry_price: float
+    size: float
+    entry_time: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+@dataclass
+class Trade:
+    """완료된 거래 정보.
+
+    Attributes:
+        symbol: 거래 심볼.
+        side: 포지션 방향.
+        entry_price: 진입 가격.
+        exit_price: 청산 가격.
+        size: 포지션 크기.
+        entry_time: 진입 시각.
+        exit_time: 청산 시각.
+        pnl_pct: 손익률 (%).
+    """
+
+    symbol: str
+    side: Literal["long", "short"]
+    entry_price: float
+    exit_price: float
+    size: float
+    entry_time: str
+    exit_time: str
+    pnl_pct: float
+
+
+class PortfolioManager:
+    """포지션 관리자.
+
+    로컬 모드(dict)와 DynamoDB 모드를 지원한다.
+
+    Attributes:
+        mode: 저장 모드 ("local" | "dynamodb").
+    """
+
+    def __init__(
+        self,
+        mode: Literal["local", "dynamodb"] = "local",
+        table_prefix: str = "cryptosentinel",
+        region: str = "ap-northeast-2",
+    ) -> None:
+        """포지션 관리자를 초기화한다.
+
+        Args:
+            mode: 저장 모드.
+            table_prefix: DynamoDB 테이블 이름 접두사.
+            region: AWS 리전 (DynamoDB 모드 시).
+        """
+        self.mode = mode
+        self._table_prefix = table_prefix
+
+        if mode == "local":
+            self._positions: dict[str, Position] = {}
+            self._trades: dict[str, list[Trade]] = {}
+            self._bot_state: dict[str, str] = {}
+        else:
+            dynamodb = boto3.resource("dynamodb", region_name=region)
+            self._positions_table = dynamodb.Table(f"{table_prefix}-positions")
+            self._trades_table = dynamodb.Table(f"{table_prefix}-trades")
+            self._bot_state_table = dynamodb.Table(f"{table_prefix}-bot-state")
+
+        logger.info(f"PortfolioManager 초기화: mode={mode}, prefix={table_prefix}")
+
+    def open_position(
+        self,
+        symbol: str,
+        side: Literal["long", "short"],
+        entry_price: float,
+        size: float,
+    ) -> Position:
+        """새 포지션을 연다.
+
+        Args:
+            symbol: 거래 심볼.
+            side: 포지션 방향.
+            entry_price: 진입 가격.
+            size: 포지션 크기 (자본 비율).
+
+        Returns:
+            생성된 Position.
+
+        Raises:
+            ValueError: 해당 심볼에 이미 오픈 포지션이 있을 때.
+        """
+        existing = self.get_current_position(symbol)
+        if existing is not None:
+            raise ValueError(f"{symbol} 포지션이 이미 존재합니다: {existing}")
+
+        position = Position(
+            symbol=symbol,
+            side=side,
+            entry_price=entry_price,
+            size=size,
+        )
+
+        if self.mode == "local":
+            self._positions[symbol] = position
+        else:
+            self._positions_table.put_item(Item=_to_dynamo_item(asdict(position)))
+
+        logger.info(f"포지션 오픈: {symbol} {side} @ {entry_price}, size={size}")
+        return position
+
+    def close_position(self, symbol: str, exit_price: float) -> Trade:
+        """포지션을 청산한다.
+
+        Args:
+            symbol: 거래 심볼.
+            exit_price: 청산 가격.
+
+        Returns:
+            완료된 Trade.
+
+        Raises:
+            ValueError: 해당 심볼에 오픈 포지션이 없을 때.
+        """
+        position = self.get_current_position(symbol)
+        if position is None:
+            raise ValueError(f"{symbol} 오픈 포지션이 없습니다.")
+
+        if position.side == "long":
+            pnl_pct = (exit_price - position.entry_price) / position.entry_price * 100
+        else:
+            pnl_pct = (position.entry_price - exit_price) / position.entry_price * 100
+
+        exit_time = datetime.now(UTC).isoformat()
+
+        trade = Trade(
+            symbol=symbol,
+            side=position.side,
+            entry_price=position.entry_price,
+            exit_price=exit_price,
+            size=position.size,
+            entry_time=position.entry_time,
+            exit_time=exit_time,
+            pnl_pct=round(pnl_pct, 4),
+        )
+
+        if self.mode == "local":
+            del self._positions[symbol]
+            self._trades.setdefault(symbol, []).append(trade)
+        else:
+            self._positions_table.delete_item(Key={"symbol": symbol})
+            self._trades_table.put_item(Item=_to_dynamo_item(asdict(trade)))
+
+        logger.info(f"포지션 청산: {symbol} {position.side} @ {exit_price}, PnL={pnl_pct:+.2f}%")
+        return trade
+
+    def get_current_position(self, symbol: str) -> Position | None:
+        """현재 오픈 포지션을 조회한다.
+
+        Args:
+            symbol: 거래 심볼.
+
+        Returns:
+            Position 또는 없으면 None.
+        """
+        if self.mode == "local":
+            return self._positions.get(symbol)
+
+        response = self._positions_table.get_item(Key={"symbol": symbol})
+        item = response.get("Item")
+        if item is None:
+            return None
+        return Position(
+            symbol=item["symbol"],
+            side=item["side"],
+            entry_price=float(item["entry_price"]),
+            size=float(item["size"]),
+            entry_time=item["entry_time"],
+        )
+
+    def get_trade_history(self, symbol: str, limit: int = 50) -> list[Trade]:
+        """거래 이력을 조회한다.
+
+        Args:
+            symbol: 거래 심볼.
+            limit: 최대 조회 건수.
+
+        Returns:
+            Trade 목록 (최신순).
+        """
+        if self.mode == "local":
+            trades = self._trades.get(symbol, [])
+            return list(reversed(trades[-limit:]))
+
+        response = self._trades_table.query(
+            KeyConditionExpression=Key("symbol").eq(symbol),
+            ScanIndexForward=False,
+            Limit=limit,
+        )
+        return [
+            Trade(
+                symbol=item["symbol"],
+                side=item["side"],
+                entry_price=float(item["entry_price"]),
+                exit_price=float(item["exit_price"]),
+                size=float(item["size"]),
+                entry_time=item["entry_time"],
+                exit_time=item["exit_time"],
+                pnl_pct=float(item["pnl_pct"]),
+            )
+            for item in response.get("Items", [])
+        ]
+
+    def get_bot_state(self, key: str) -> str | None:
+        """봇 상태 값을 조회한다.
+
+        Args:
+            key: 상태 키 (e.g., "running", "last_signal").
+
+        Returns:
+            값 문자열 또는 없으면 None.
+        """
+        if self.mode == "local":
+            return self._bot_state.get(key)
+
+        response = self._bot_state_table.get_item(Key={"key": key})
+        item = response.get("Item")
+        return item["value"] if item else None
+
+    def set_bot_state(self, key: str, value: str) -> None:
+        """봇 상태 값을 설정한다.
+
+        Args:
+            key: 상태 키.
+            value: 값 문자열.
+        """
+        if self.mode == "local":
+            self._bot_state[key] = value
+        else:
+            self._bot_state_table.put_item(Item={"key": key, "value": value})
+
+        logger.debug(f"봇 상태 설정: {key}={value}")
+
+    def delete_bot_state(self, key: str) -> None:
+        """봇 상태 값을 삭제한다.
+
+        Args:
+            key: 상태 키.
+        """
+        if self.mode == "local":
+            self._bot_state.pop(key, None)
+        else:
+            self._bot_state_table.delete_item(Key={"key": key})
+
+
+def _to_dynamo_item(d: dict) -> dict:
+    """Python dict를 DynamoDB 호환 아이템으로 변환한다.
+
+    float → Decimal 변환 (DynamoDB는 float 미지원).
+
+    Args:
+        d: 원본 딕셔너리.
+
+    Returns:
+        Decimal 변환된 딕셔너리.
+    """
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, float):
+            result[k] = Decimal(str(v))
+        else:
+            result[k] = v
+    return result

--- a/src/strategy/portfolio.py
+++ b/src/strategy/portfolio.py
@@ -73,6 +73,7 @@ class PortfolioManager:
         self,
         mode: Literal["local", "dynamodb"] = "local",
         table_prefix: str = "cryptosentinel",
+        env_name: str = "dev",
         region: str = "ap-northeast-2",
     ) -> None:
         """포지션 관리자를 초기화한다.
@@ -80,6 +81,7 @@ class PortfolioManager:
         Args:
             mode: 저장 모드.
             table_prefix: DynamoDB 테이블 이름 접두사.
+            env_name: 환경 이름 (dev/prod). CDK 테이블 이름과 매칭.
             region: AWS 리전 (DynamoDB 모드 시).
         """
         self.mode = mode
@@ -91,11 +93,11 @@ class PortfolioManager:
             self._bot_state: dict[str, str] = {}
         else:
             dynamodb = boto3.resource("dynamodb", region_name=region)
-            self._positions_table = dynamodb.Table(f"{table_prefix}-positions")
-            self._trades_table = dynamodb.Table(f"{table_prefix}-trades")
-            self._bot_state_table = dynamodb.Table(f"{table_prefix}-bot-state")
+            self._positions_table = dynamodb.Table(f"{table_prefix}-positions-{env_name}")
+            self._trades_table = dynamodb.Table(f"{table_prefix}-trades-{env_name}")
+            self._bot_state_table = dynamodb.Table(f"{table_prefix}-bot-state-{env_name}")
 
-        logger.info(f"PortfolioManager 초기화: mode={mode}, prefix={table_prefix}")
+        logger.info(f"PortfolioManager 초기화: mode={mode}, prefix={table_prefix}, env={env_name}")
 
     def open_position(
         self,

--- a/tests/unit/test_portfolio.py
+++ b/tests/unit/test_portfolio.py
@@ -1,0 +1,157 @@
+"""포지션 관리 모듈 단위 테스트."""
+
+import pytest
+
+from src.strategy.portfolio import PortfolioManager, Position, Trade
+
+
+class TestOpenPosition:
+    """open_position 테스트."""
+
+    def test_open_long_position(self) -> None:
+        """롱 포지션을 정상적으로 연다."""
+        pm = PortfolioManager(mode="local")
+        pos = pm.open_position("BTC/USDT", "long", 50000.0, 0.5)
+
+        assert isinstance(pos, Position)
+        assert pos.symbol == "BTC/USDT"
+        assert pos.side == "long"
+        assert pos.entry_price == 50000.0
+        assert pos.size == 0.5
+
+    def test_open_short_position(self) -> None:
+        """숏 포지션을 정상적으로 연다."""
+        pm = PortfolioManager(mode="local")
+        pos = pm.open_position("BTC/USDT", "short", 50000.0, 0.3)
+
+        assert pos.side == "short"
+        assert pos.size == 0.3
+
+    def test_duplicate_open_raises(self) -> None:
+        """같은 심볼에 중복 오픈 시 ValueError."""
+        pm = PortfolioManager(mode="local")
+        pm.open_position("BTC/USDT", "long", 50000.0, 0.5)
+
+        with pytest.raises(ValueError, match="이미 존재"):
+            pm.open_position("BTC/USDT", "long", 51000.0, 0.3)
+
+    def test_open_different_symbols(self) -> None:
+        """다른 심볼은 각각 오픈 가능."""
+        pm = PortfolioManager(mode="local")
+        pm.open_position("BTC/USDT", "long", 50000.0, 0.5)
+        pm.open_position("ETH/USDT", "long", 3000.0, 0.3)
+
+        assert pm.get_current_position("BTC/USDT") is not None
+        assert pm.get_current_position("ETH/USDT") is not None
+
+
+class TestClosePosition:
+    """close_position 테스트."""
+
+    def test_close_long_profit(self) -> None:
+        """롱 포지션 수익 청산."""
+        pm = PortfolioManager(mode="local")
+        pm.open_position("BTC/USDT", "long", 50000.0, 0.5)
+        trade = pm.close_position("BTC/USDT", 55000.0)
+
+        assert isinstance(trade, Trade)
+        assert trade.pnl_pct == pytest.approx(10.0, abs=0.01)
+        assert pm.get_current_position("BTC/USDT") is None
+
+    def test_close_long_loss(self) -> None:
+        """롱 포지션 손실 청산."""
+        pm = PortfolioManager(mode="local")
+        pm.open_position("BTC/USDT", "long", 50000.0, 0.5)
+        trade = pm.close_position("BTC/USDT", 48000.0)
+
+        assert trade.pnl_pct == pytest.approx(-4.0, abs=0.01)
+
+    def test_close_short_profit(self) -> None:
+        """숏 포지션 수익 청산."""
+        pm = PortfolioManager(mode="local")
+        pm.open_position("BTC/USDT", "short", 50000.0, 0.5)
+        trade = pm.close_position("BTC/USDT", 45000.0)
+
+        assert trade.pnl_pct == pytest.approx(10.0, abs=0.01)
+
+    def test_close_no_position_raises(self) -> None:
+        """오픈 포지션 없이 청산 시 ValueError."""
+        pm = PortfolioManager(mode="local")
+
+        with pytest.raises(ValueError, match="오픈 포지션이 없습니다"):
+            pm.close_position("BTC/USDT", 50000.0)
+
+
+class TestGetPosition:
+    """get_current_position 테스트."""
+
+    def test_no_position_returns_none(self) -> None:
+        """포지션 없으면 None."""
+        pm = PortfolioManager(mode="local")
+        assert pm.get_current_position("BTC/USDT") is None
+
+    def test_get_open_position(self) -> None:
+        """오픈 포지션 조회."""
+        pm = PortfolioManager(mode="local")
+        pm.open_position("BTC/USDT", "long", 50000.0, 0.5)
+
+        pos = pm.get_current_position("BTC/USDT")
+        assert pos is not None
+        assert pos.entry_price == 50000.0
+
+
+class TestTradeHistory:
+    """get_trade_history 테스트."""
+
+    def test_empty_history(self) -> None:
+        """거래 이력 없으면 빈 리스트."""
+        pm = PortfolioManager(mode="local")
+        assert pm.get_trade_history("BTC/USDT") == []
+
+    def test_history_after_trades(self) -> None:
+        """거래 후 이력 조회."""
+        pm = PortfolioManager(mode="local")
+        pm.open_position("BTC/USDT", "long", 50000.0, 0.5)
+        pm.close_position("BTC/USDT", 52000.0)
+        pm.open_position("BTC/USDT", "long", 53000.0, 0.5)
+        pm.close_position("BTC/USDT", 51000.0)
+
+        history = pm.get_trade_history("BTC/USDT")
+        assert len(history) == 2
+        # 최신순
+        assert history[0].pnl_pct < 0  # 두 번째 거래: 손실
+        assert history[1].pnl_pct > 0  # 첫 번째 거래: 수익
+
+    def test_history_limit(self) -> None:
+        """이력 조회 limit 적용."""
+        pm = PortfolioManager(mode="local")
+        for i in range(5):
+            pm.open_position("BTC/USDT", "long", 50000.0 + i * 100, 0.5)
+            pm.close_position("BTC/USDT", 50100.0 + i * 100)
+
+        history = pm.get_trade_history("BTC/USDT", limit=3)
+        assert len(history) == 3
+
+
+class TestBotState:
+    """봇 상태 관리 테스트."""
+
+    def test_set_and_get(self) -> None:
+        """상태 설정 후 조회."""
+        pm = PortfolioManager(mode="local")
+        pm.set_bot_state("running", "true")
+
+        assert pm.get_bot_state("running") == "true"
+
+    def test_get_nonexistent(self) -> None:
+        """존재하지 않는 키 조회 시 None."""
+        pm = PortfolioManager(mode="local")
+        assert pm.get_bot_state("nonexistent") is None
+
+    def test_delete_state(self) -> None:
+        """상태 삭제."""
+        pm = PortfolioManager(mode="local")
+        pm.set_bot_state("running", "true")
+        pm.delete_bot_state("running")
+
+        assert pm.get_bot_state("running") is None


### PR DESCRIPTION
## Summary
- PortfolioManager: 로컬 dict / DynamoDB 듀얼 모드 포지션 CRUD
- CDK TradingStack: positions, trades, bot-state DynamoDB 테이블 3개 (On-Demand)
- 포지션 오픈/청산, 거래 이력, 봇 상태 관리 지원

Closes #34

## Changes
- `src/strategy/portfolio.py`: 포지션 관리 모듈 (신규)
- `infra/lib/trading-stack.ts`: DynamoDB 테이블 CDK 정의 (신규)
- `infra/bin/app.ts`: TradingStack 인스턴스 추가 (수정)
- `tests/unit/test_portfolio.py`: 단위 테스트 16건 (신규)

## Test plan
- [x] 16개 단위 테스트 통과 (open/close/get/history/bot-state)
- [x] `npx tsc --noEmit` 컴파일 통과
- [x] `npx cdk synth CryptoSentinel-Trading-dev` 정상 생성
- [x] DynamoDB 3개 테이블: PAY_PER_REQUEST, dev=DESTROY, prod=RETAIN+PITR
- [x] `ruff check` + `ruff format --check` 통과
- [x] 전체 스위트 400개 회귀 테스트 통과